### PR TITLE
Fix: guard against undefined search form reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ez.hress.reactweb",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ez.hress.reactweb",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "@sentry/cli": "^3.4.3",
         "@sentry/react": "^10.54.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez.hress.reactweb",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -56,7 +56,7 @@
 					if (!$search.hasClass('visible')) {
 
 						// Reset form.
-							$search[0].reset();
+							if ($search[0]) $search[0].reset();
 
 						// Show.
 							$search.addClass('visible');


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Cannot read properties of undefined (reading 'reset')` in `main.js:59`
- The error occurred when a `[href="#search"]` link was clicked on a page that has no `<form id="search">` element, making `$search[0]` undefined
- Added a null guard: `if ($search[0]) $search[0].reset()`

Closes #667

## Test plan
- [ ] Click a search link on a page that has the search form — form should reset and become visible as before
- [ ] Confirm no JS error is thrown on pages without the search form element

🤖 Generated with [Claude Code](https://claude.com/claude-code)