### PR TITLE
Migrate: hardhead statistics sidebar to new API (#673)

### DIFF
--- a/docs/superpowers/plans/2026-05-27-hardhead-statistics-sidebar-migration.md
+++ b/docs/superpowers/plans/2026-05-27-hardhead-statistics-sidebar-migration.md
@@ -1,0 +1,161 @@
+# Hardhead Statistics Sidebar Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `statisticsSide.js` off the legacy API (`config.get("path")` + `code` param) onto the new Azure Functions API (`config.get("apiPath")`), matching all peer files in the same directory.
+
+**Architecture:** Single-file change. Replace the minute-based branching and legacy URL construction inside `useEffect` with `Math.random()` + `URLSearchParams`. Update all response property reads from PascalCase to camelCase and add a null-guard on the profile photo.
+
+**Tech Stack:** React (functional component, hooks), axios, react-global-configuration.
+
+---
+
+### Task 1: Update `statisticsSide.js`
+
+**Files:**
+- Modify: `src/pages/hardhead/statistics/statisticsSide.js`
+
+This is the only file that changes. No new files, no peer files, no API changes.
+
+#### Context
+
+Current file (`src/pages/hardhead/statistics/statisticsSide.js`) constructs two different legacy URLs using `config.get("path")` and appends `&code=${config.get("code")}`. Both branches hit `ezhressapi.azurewebsites.net`.
+
+The new endpoint is `GET ${config.get("apiPath")}/api/hardhead/statistics/users` with optional query params `periodType` (int 0–4, maps to `All/Last10/Last5/Last2/ThisYear`) and `attendanceType` (int; omit or 0 → server defaults to 52 "gestur"; pass 53 for host stats). No `code` param — the Azure Function uses function-level auth automatically.
+
+The new API returns camelCase JSON. The existing render block reads PascalCase (`data.stats.List`, `data.stats.PeriodTypeName`, etc.) — all must be updated.
+
+- [ ] **Step 1: Replace the entire file content**
+
+Open `src/pages/hardhead/statistics/statisticsSide.js` and replace it with:
+
+```js
+import { useState, useEffect } from "react";
+import config from "react-global-configuration";
+import { MiniPost } from "../../../components";
+import axios from "axios";
+
+const StatisticsSide = () => {
+  const [data, setData] = useState({
+    stats: null,
+    isLoading: false,
+    visible: false,
+  });
+
+  useEffect(() => {
+    const getAwards = async () => {
+      try {
+        const isHost = Math.random() < 0.5;
+        const periodType = Math.round(Math.random() * 4);
+        const params = new URLSearchParams({ periodType });
+        if (isHost) params.set("attendanceType", "53");
+        const url = `${config.get("apiPath")}/api/hardhead/statistics/users?${params}`;
+
+        setData({ isLoading: true });
+        const response = await axios.get(url);
+        setData({ stats: response.data, isLoading: false, visible: true });
+      } catch (e) {
+        console.error(e);
+        setData({ isLoading: false, visible: false });
+      }
+    };
+
+    if (!data.stats) {
+      getAwards();
+    }
+  }, []);
+
+  const getDescription = (period, guest) => {
+    let description = "gestur";
+
+    if (guest === "gestur") description = "Oftast mætt";
+    else description = "Oftast haldið";
+
+    if (period === "All") description = `${description} frá upphafi`;
+    else if (period === "Last10")
+      description = `${description} síðustu 10 álin`;
+    else if (period === "Last5") description = `${description} síðustu 5 álin`;
+    else if (period === "Last2") description = `${description} síðustu 2 álin`;
+    else if (period === "ThisYear") description = `${description}  á þessu ári`;
+
+    return description;
+  };
+
+  const top = data.stats ? data.stats.list[0] : null;
+
+  return (
+    <div>
+      {data.visible && top ? (
+        <MiniPost
+          title="Tölfræði"
+          href="/hardhead/stats"
+          description={
+            <span>
+              {getDescription(data.stats.periodTypeName, data.stats.typeName)}
+              <br />
+              {top.user.username} - {top.attendedCount}
+              <br />
+              {top.firstAttendedString} - {top.lastAttendedString}
+            </span>
+          }
+          date={data.stats.dateFrom}
+          dateString={data.stats.dateFromString}
+          userHref={`/hardhead/users/${top.user.id}`}
+          userPhoto={
+            top.user.profilePhoto
+              ? config.get("apiPath") + top.user.profilePhoto.href
+              : undefined
+          }
+          userText={top.user.username}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default StatisticsSide;
+```
+
+Key changes from the original:
+- `config.get("path")` → `config.get("apiPath")` (both branches)
+- `&code=${config.get("code")}` removed
+- `new Date().getMinutes() % 2 === 0` → `Math.random() < 0.5`
+- `guestType=53` → `attendanceType=53`
+- Single `periodType` random value replaces two separate ones
+- All response property accesses updated to camelCase (`List` → `list`, `PeriodTypeName` → `periodTypeName`, `TypeName` → `typeName`, `DateFrom` → `dateFrom`, `DateFromString` → `dateFromString`, `User.Username` → `user.username`, `User.ID` → `user.id`, `User.ProfilePhoto.Href` → `user.profilePhoto.href`)
+- `top.user.profilePhoto` null guard added (server returns `null` when user has no photo)
+
+- [ ] **Step 2: Verify no legacy config references remain in this file**
+
+Run:
+```bash
+grep -n 'config\.get("path")\|config\.get("code")' src/pages/hardhead/statistics/statisticsSide.js
+```
+
+Expected: no output (zero matches).
+
+- [ ] **Step 3: Start the dev server and verify the sidebar loads**
+
+```bash
+npm start
+```
+
+Navigate to `http://localhost:3000/hardhead` in the browser. The statistics sidebar (`MiniPost` titled "Tölfræði") should appear. Open DevTools → Network tab, filter for `statistics/users`, and confirm:
+
+- The request URL starts with `apiPath` (the Azure Functions base URL, e.g. `https://ezhressapi2.azurewebsites.net` or similar from your `.env`), **not** `ezhressapi.azurewebsites.net`.
+- The request URL contains `periodType=` but no `code=` parameter.
+- On the "host" branch (one in two reloads, roughly) the URL also contains `attendanceType=53`.
+- The widget renders a username, attended count, and two date strings without a JavaScript error.
+
+Reload the page 6–10 times to exercise both branches. Check the browser console for errors after each reload.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/hardhead/statistics/statisticsSide.js
+git commit -m "Migrate: statisticsSide to new API (#673)
+
+Replace legacy config.get(\"path\") + code param with config.get(\"apiPath\").
+Update guestType→attendanceType, minute-branch→Math.random(), PascalCase→camelCase,
+and add null-guard on profilePhoto."
+```

--- a/docs/superpowers/plans/2026-05-27-hardhead-statistics-sidebar-migration.md
+++ b/docs/superpowers/plans/2026-05-27-hardhead-statistics-sidebar-migration.md
@@ -73,15 +73,15 @@ const StatisticsSide = () => {
 
     if (period === "All") description = `${description} frá upphafi`;
     else if (period === "Last10")
-      description = `${description} síðustu 10 álin`;
-    else if (period === "Last5") description = `${description} síðustu 5 álin`;
-    else if (period === "Last2") description = `${description} síðustu 2 álin`;
+      description = `${description} síðustu 10 árin`;
+    else if (period === "Last5") description = `${description} síðustu 5 árin`;
+    else if (period === "Last2") description = `${description} síðustu 2 árin`;
     else if (period === "ThisYear") description = `${description}  á þessu ári`;
 
     return description;
   };
 
-  const top = data.stats ? data.stats.list[0] : null;
+  const top = data.stats?.list?.[0] ?? null;
 
   return (
     <div>

--- a/docs/superpowers/specs/2026-05-27-hardhead-statistics-sidebar-migration-design.md
+++ b/docs/superpowers/specs/2026-05-27-hardhead-statistics-sidebar-migration-design.md
@@ -1,0 +1,115 @@
+# Hardhead Statistics Sidebar Migration — Legacy API → New API
+
+**Issue:** [#673](https://github.com/kromby/Hress.Org/issues/673)
+**Date:** 2026-05-27
+**Status:** Approved (design)
+
+## Background
+
+The site is migrating off the legacy Azure Web API (`REACT_APP_LEGACY_API_PATH` → `ezhressapi.azurewebsites.net`) onto the new Azure Functions API in `Hress.Org/api/` (`Ez.Hress.FunctionsApi`).
+
+The hardhead statistics sidebar (`src/pages/hardhead/statistics/statisticsSide.js`) still hits the legacy API on both of its random branches. Peer files in the same directory — `hostStats.js`, `guestStats.js`, `attendanceStats.js`, `actorStats.js` — already use `config.get("apiPath")`. This one was missed.
+
+The new endpoint is fully implemented and in use by the peer files:
+
+- `HardheadStatisticFunctions.RunUsers` (`api/Ez.Hress.FunctionsApi/Hardhead/HardheadStatisticFunctions.cs:64`) → `HardheadStatisticsInteractor.GetUserStatisticsAsync` → `HardheadStatisticSqlDataAccess.GetUserStatistic`.
+- Route: `GET hardhead/statistics/users/{id:int?}`, Function-level auth.
+- Query params: `periodType` (enum: `All`, `Last10`, `Last5`, `Last2`, `ThisYear`) and `attendanceType` (int; defaults to 52 — "gestur" — when 0 or omitted).
+
+## Goal
+
+The sidebar widget loads stats from the new API on both random branches, with no remaining references to `config.get("path")` or `config.get("code")` in the file.
+
+## Non-goals
+
+- Refactoring peer statistics files (`hostStats.js`, `guestStats.js`, etc.).
+- Extracting a shared `useHardheadUserStats` hook.
+- Restructuring the file to put `const url = ...` at the top level (already considered and rejected — current useEffect-local structure stays).
+- Changes to the new API or its data access layer.
+- Adding tests (no existing tests for this file or its peers).
+
+## Design
+
+### 1. URL construction
+
+Inside `useEffect`, compute the random pick once and build the URL via `URLSearchParams`:
+
+```js
+const isHost = Math.random() < 0.5;
+const periodType = Math.round(Math.random() * 4); // 0..4 maps to PeriodType enum positions
+const params = new URLSearchParams({ periodType });
+if (isHost) params.set("attendanceType", "53");
+const url = `${config.get("apiPath")}/api/hardhead/statistics/users?${params}`;
+```
+
+Changes vs. today:
+
+- `config.get("path")` → `config.get("apiPath")`.
+- `&code=${config.get("code")}` dropped (new API uses Function-level auth, like peer files).
+- `guestType=53` → `attendanceType=53` (the new API does not read `guestType`; peer `hostStats.js` already uses `attendanceType=53`). When `isHost` is false, the parameter is omitted, defaulting server-side to `attendanceType=52` ("gestur").
+- Minute-based branching (`new Date().getMinutes() % 2 === 0`) replaced with `Math.random() < 0.5` — confirmed during brainstorming as the intended semantics. Two computed `periodType` values (one per branch) collapse to a single random value used by both branches.
+
+### 2. Render block (camelCase + null-safe photo)
+
+The new API returns camelCase JSON. Update all property reads, and guard the profile photo against `null` (the existing code crashes if the top user has no photo — `UserBasicEntity.ProfilePhoto` returns null when `ProfilePhotoId == 0`):
+
+```jsx
+const top = data.stats.list[0];
+
+<MiniPost
+  title="Tölfræði"
+  href="/hardhead/stats"
+  description={
+    <span>
+      {getDescription(data.stats.periodTypeName, data.stats.typeName)}
+      <br />
+      {top.user.username} - {top.attendedCount}
+      <br />
+      {top.firstAttendedString} - {top.lastAttendedString}
+    </span>
+  }
+  date={data.stats.dateFrom}
+  dateString={data.stats.dateFromString}
+  userHref={`/hardhead/users/${top.user.id}`}
+  userPhoto={top.user.profilePhoto ? config.get("apiPath") + top.user.profilePhoto.href : undefined}
+  userText={top.user.username}
+/>
+```
+
+Property mapping (legacy PascalCase → new camelCase):
+
+| Legacy | New |
+|---|---|
+| `data.stats.PeriodTypeName` | `data.stats.periodTypeName` |
+| `data.stats.TypeName` | `data.stats.typeName` |
+| `data.stats.DateFrom` | `data.stats.dateFrom` |
+| `data.stats.DateFromString` | `data.stats.dateFromString` |
+| `data.stats.List[0]` | `data.stats.list[0]` |
+| `.AttendedCount` | `.attendedCount` |
+| `.FirstAttendedString` / `.LastAttendedString` | `.firstAttendedString` / `.lastAttendedString` |
+| `.User.ID` / `.User.Username` | `.user.id` / `.user.username` |
+| `.User.ProfilePhoto.Href` | `.user.profilePhoto.href` (nullable) |
+
+`typeName` continues to compare against `"gestur"` in `getDescription` — the interactor sets it to `attendanceType.Name.ToLower()`, which is `"gestur"` for type 52 (the default branch).
+
+### 3. Files changed
+
+Single file: `src/pages/hardhead/statistics/statisticsSide.js`. No new files, no shared changes, no peer changes, no test changes.
+
+## Testing
+
+Manual verification only (no automated tests exist for this file or its peers):
+
+- Load any page that mounts the sidebar widget; reload several times to exercise both random branches.
+- Confirm in network tab that both branches hit `apiPath` (Azure Functions), not `ezhressapi.azurewebsites.net`.
+- Confirm no `&code=` query parameter is present on the request URL.
+- Confirm the rendered widget shows username, attended count, and date strings correctly for both `attendanceType=52` (no param, "Oftast mætt") and `attendanceType=53` ("Oftast haldið") branches.
+- Confirm the sidebar does not crash when the top user has no profile photo (manually exercise by picking a `periodType` whose top result lacks a photo, if one exists in the data).
+
+## Acceptance
+
+From the issue:
+
+- The sidebar widget loads stats from the new API.
+- Both random branches (with and without `attendanceType=53`) work.
+- No remaining references to `config.get("path")` or `config.get("code")` in this file.

--- a/src/pages/hardhead/statistics/statisticsSide.js
+++ b/src/pages/hardhead/statistics/statisticsSide.js
@@ -13,23 +13,11 @@ const StatisticsSide = () => {
   useEffect(() => {
     const getAwards = async () => {
       try {
-        const min = 0;
-        const max = 4;
-        const periodType = Math.round(min + Math.random() * (max - min));
-
-        let url = "";
-        if (new Date().getMinutes() % 2 === 0)
-          url = `${config.get(
-            "path"
-          )}/api/hardhead/statistics/users?periodType=${periodType}&code=${config.get(
-            "code"
-          )}`;
-        else
-          url = `${config.get(
-            "path"
-          )}/api/hardhead/statistics/users?guestType=53&periodType=${periodType}&code=${config.get(
-            "code"
-          )}`;
+        const isHost = Math.random() < 0.5;
+        const periodType = Math.round(Math.random() * 4);
+        const params = new URLSearchParams({ periodType });
+        if (isHost) params.set("attendanceType", "53");
+        const url = `${config.get("apiPath")}/api/hardhead/statistics/users?${params}`;
 
         setData({ isLoading: true });
         const response = await axios.get(url);
@@ -51,41 +39,42 @@ const StatisticsSide = () => {
     if (guest === "gestur") description = "Oftast mætt";
     else description = "Oftast haldið";
 
-    // console.log(period);
     if (period === "All") description = `${description} frá upphafi`;
     else if (period === "Last10")
-      description = `${description} síðustu 10 árin`;
-    else if (period === "Last5") description = `${description} síðustu 5 árin`;
-    else if (period === "Last2") description = `${description} síðustu 2 árin`;
+      description = `${description} síðustu 10 álin`;
+    else if (period === "Last5") description = `${description} síðustu 5 álin`;
+    else if (period === "Last2") description = `${description} síðustu 2 álin`;
     else if (period === "ThisYear") description = `${description}  á þessu ári`;
 
     return description;
   };
 
+  const top = data.stats ? data.stats.list[0] : null;
+
   return (
     <div>
-      {data.visible ? (
+      {data.visible && top ? (
         <MiniPost
           title="Tölfræði"
           href="/hardhead/stats"
           description={
             <span>
-              {getDescription(data.stats.PeriodTypeName, data.stats.TypeName)}
+              {getDescription(data.stats.periodTypeName, data.stats.typeName)}
               <br />
-              {data.stats.List[0].User.Username} -{" "}
-              {data.stats.List[0].AttendedCount}
+              {top.user.username} - {top.attendedCount}
               <br />
-              {data.stats.List[0].FirstAttendedString} -{" "}
-              {data.stats.List[0].LastAttendedString}
+              {top.firstAttendedString} - {top.lastAttendedString}
             </span>
           }
-          date={data.stats.DateFrom}
-          dateString={data.stats.DateFromString}
-          userHref={`/hardhead/users/${data.stats.List[0].User.ID}`}
+          date={data.stats.dateFrom}
+          dateString={data.stats.dateFromString}
+          userHref={`/hardhead/users/${top.user.id}`}
           userPhoto={
-            config.get("apiPath") + data.stats.List[0].User.ProfilePhoto.Href
+            top.user.profilePhoto
+              ? config.get("apiPath") + top.user.profilePhoto.href
+              : undefined
           }
-          userText={data.stats.List[0].User.Username}
+          userText={top.user.username}
         />
       ) : null}
     </div>

--- a/src/pages/hardhead/statistics/statisticsSide.js
+++ b/src/pages/hardhead/statistics/statisticsSide.js
@@ -49,7 +49,7 @@ const StatisticsSide = () => {
     return description;
   };
 
-  const top = data.stats ? data.stats.list[0] : null;
+  const top = data.stats?.list?.[0] ?? null;
 
   return (
     <div>

--- a/src/pages/hardhead/statistics/statisticsSide.js
+++ b/src/pages/hardhead/statistics/statisticsSide.js
@@ -41,9 +41,9 @@ const StatisticsSide = () => {
 
     if (period === "All") description = `${description} frá upphafi`;
     else if (period === "Last10")
-      description = `${description} síðustu 10 álin`;
-    else if (period === "Last5") description = `${description} síðustu 5 álin`;
-    else if (period === "Last2") description = `${description} síðustu 2 álin`;
+      description = `${description} síðustu 10 árin`;
+    else if (period === "Last5") description = `${description} síðustu 5 árin`;
+    else if (period === "Last2") description = `${description} síðustu 2 árin`;
     else if (period === "ThisYear") description = `${description}  á þessu ári`;
 
     return description;


### PR DESCRIPTION
## Summary

- Replace legacy `config.get("path")` + `&code=` param with `config.get("apiPath")` in `statisticsSide.js` — the last file in `src/pages/hardhead/statistics/` still hitting the old API
- Rename `guestType=53` → `attendanceType=53` to match the new API's query parameter and use `URLSearchParams` for URL construction
- Replace minute-based random branch (`new Date().getMinutes() % 2`) with `Math.random() < 0.5`, and update all PascalCase response property reads to camelCase to match the new API's JSON serialization
- Add null guard for `profilePhoto` (server returns `null` when a user has no photo — consistent with peer files `hostStats.js` / `guestStats.js`)

## Test Plan

- [ ] Navigate to `/hardhead` and confirm the "Tölfræði" sidebar widget renders with a username, attended count, and date strings
- [ ] Open DevTools → Network tab and confirm requests go to `apiPath` (Azure Functions), not `ezhressapi.azurewebsites.net`, and contain no `&code=` param
- [ ] Reload 6–10 times to exercise both random branches — confirm some requests include `attendanceType=53` (host) and others omit it (guest, default=52)
- [ ] Confirm no JavaScript errors in the browser console

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration plan and design specifications for statistics sidebar backend API transition.

* **Bug Fixes**
  * Improved statistics sidebar handling for users without profile photos to prevent rendering errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kromby/Hress.Org/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->