### PR TITLE
Cleanup: remove legacy API config keys from index.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Create a `.env` file in the repo root:
 ```
 REACT_APP_API_PATH=http://localhost:7072
 
-REACT_APP_LEGACY_API_PATH=https://ezhressapi.azurewebsites.net
-REACT_APP_LEGACY_API_CODE=ADD CODE HERE
-
 REACT_APP_IMAGE_PATH=https://ezcontentapi.azurewebsites.net
 
 REACT_APP_OMDB=ADD KEY HERE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ez.hress.reactweb",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ez.hress.reactweb",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "dependencies": {
         "@sentry/cli": "^3.4.3",
         "@sentry/react": "^10.54.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez.hress.reactweb",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,8 @@ Sentry.init({
 function setConfig() {
   config.set(
     {
-      path: process.env.REACT_APP_LEGACY_API_PATH,
       apiPath: process.env.REACT_APP_API_PATH ?? window.location.hostname,
       imagePath: process.env.REACT_APP_IMAGE_PATH,
-      code: process.env.REACT_APP_LEGACY_API_CODE,
       omdb: process.env.REACT_APP_OMDB,
     },
     {


### PR DESCRIPTION
## Summary

- Remove `path` and `code` from the `react-global-configuration` setup in `src/index.js`
- Remove corresponding `REACT_APP_LEGACY_API_PATH` and `REACT_APP_LEGACY_API_CODE` env var reads

These keys were the last tie to the legacy API (`ezhressapi.azurewebsites.net`). With #673 merged (statistics sidebar), no component in `src/` reads `config.get("path")` or `config.get("code")` anymore.

## Test Plan

- [ ] `grep -r 'config\.get("path")\|config\.get("code")' src/` returns no matches
- [ ] App builds and runs normally — no runtime errors from missing config keys

Note: `REACT_APP_LEGACY_API_PATH` and `REACT_APP_LEGACY_API_CODE` should also be removed from any CI/deployment environment configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)